### PR TITLE
Remove redundant check

### DIFF
--- a/Source/Engine/Render/Private/FrameLoop.cpp
+++ b/Source/Engine/Render/Private/FrameLoop.cpp
@@ -39,8 +39,6 @@ void FrameLoop::Draw(RenderCommands renderCommands)
 
     const auto& [acquireResult, imageIndex] = device.acquireNextImageKHR(
             swapchain, Numbers::kMaxUint, presentCompleteSemaphore, nullptr);
-
-    if (acquireResult == vk::Result::eErrorOutOfDateKHR) return;
     Assert(acquireResult == vk::Result::eSuccess || acquireResult == vk::Result::eSuboptimalKHR);
 
     VulkanHelpers::WaitForFences(device, { renderingFence });


### PR DESCRIPTION
Removed redundant check. vulkan.hpp has check for valid values in the assert for this case (with defined VULKAN_HPP_NO_EXCEPTIONS). 